### PR TITLE
Updates name in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@papercups-io/chat-widget",
+  "name": "@papercups-io/chat-builder",
   "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
Looks like the package-lock.json file still has the old name of the chat-builder widget. Running `npm install` surfaced this. Adding this commit to update the name.